### PR TITLE
Corrected issue

### DIFF
--- a/sphinx/tutorial/rose/furthertopics/optional-configurations.rst
+++ b/sphinx/tutorial/rose/furthertopics/optional-configurations.rst
@@ -120,7 +120,7 @@ following lines:
    [env]
    FLAVOUR=fudge
    CONE_TYPE=tub
-   TOPPINGS=nuts
+   TOPPING=nuts
 
 Run the app using both the ``chocolate`` and ``fudge-sundae`` optional
 configurations::


### PR DESCRIPTION
Incorrect instructions - TOPPINGS  changed to TOPPING to ensure the exercise works as planned.